### PR TITLE
Forgot about ngl

### DIFF
--- a/docs/api/interfaces/inglhoverinfo.html
+++ b/docs/api/interfaces/inglhoverinfo.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html class="default no-js">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<title>INGLHoverInfo | bioblocks-viz - v0.0.153</title>
+	<meta name="description" content="">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="stylesheet" href="../assets/css/main.css">
+</head>
+<body>
+<header>
+	<div class="tsd-page-toolbar">
+		<div class="container">
+			<div class="table-wrap">
+				<div class="table-cell" id="tsd-search" data-index="../assets/js/search.js" data-base="..">
+					<div class="field">
+						<label for="tsd-search-field" class="tsd-widget search no-caption">Search</label>
+						<input id="tsd-search-field" type="text" />
+					</div>
+					<ul class="results">
+						<li class="state loading">Preparing search index...</li>
+						<li class="state failure">The search index is not available</li>
+					</ul>
+					<a href="../index.html" class="title">bioblocks-viz - v0.0.153</a>
+				</div>
+				<div class="table-cell" id="tsd-widgets">
+					<div id="tsd-filter">
+						<a href="#" class="tsd-widget options no-caption" data-toggle="options">Options</a>
+						<div class="tsd-filter-group">
+							<div class="tsd-select" id="tsd-filter-visibility">
+								<span class="tsd-select-label">All</span>
+								<ul class="tsd-select-list">
+									<li data-value="public">Public</li>
+									<li data-value="protected">Public/Protected</li>
+									<li data-value="private" class="selected">All</li>
+								</ul>
+							</div>
+							<input type="checkbox" id="tsd-filter-inherited" checked />
+							<label class="tsd-widget" for="tsd-filter-inherited">Inherited</label>
+							<input type="checkbox" id="tsd-filter-only-exported" />
+							<label class="tsd-widget" for="tsd-filter-only-exported">Only exported</label>
+						</div>
+					</div>
+					<a href="#" class="tsd-widget menu no-caption" data-toggle="menu">Menu</a>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="tsd-page-title">
+		<div class="container">
+			<ul class="tsd-breadcrumb">
+				<li>
+					<a href="../globals.html">Globals</a>
+				</li>
+				<li>
+					<a href="inglhoverinfo.html">INGLHoverInfo</a>
+				</li>
+			</ul>
+			<h1>Interface INGLHoverInfo</h1>
+		</div>
+	</div>
+</header>
+<div class="container container-main">
+	<div class="row">
+		<div class="col-8 col-content">
+			<section class="tsd-panel tsd-hierarchy">
+				<h3>Hierarchy</h3>
+				<ul class="tsd-hierarchy">
+					<li>
+						<span class="target">INGLHoverInfo</span>
+					</li>
+				</ul>
+			</section>
+			<section class="tsd-panel-group tsd-index-group">
+				<h2>Index</h2>
+				<section class="tsd-panel tsd-index-panel">
+					<div class="tsd-index-content">
+						<section class="tsd-index-section ">
+							<h3>Properties</h3>
+							<ul class="tsd-index-list">
+								<li class="tsd-kind-property tsd-parent-kind-interface"><a href="inglhoverinfo.html#atom" class="tsd-kind-icon">atom</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface"><a href="inglhoverinfo.html#pickingproxy" class="tsd-kind-icon">picking<wbr>Proxy</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface"><a href="inglhoverinfo.html#stage" class="tsd-kind-icon">stage</a></li>
+							</ul>
+						</section>
+					</div>
+				</section>
+			</section>
+			<section class="tsd-panel-group tsd-member-group ">
+				<h2>Properties</h2>
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface">
+					<a name="atom" class="tsd-anchor"></a>
+					<h3>atom</h3>
+					<div class="tsd-signature tsd-kind-icon">atom<span class="tsd-signature-symbol">:</span> <a href="../classes/_ngl_.atomproxy.html" class="tsd-signature-type">AtomProxy</a></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/cBioCenter/bioblocks-viz/blob/10ae9ca5a/src/component/NGLComponent.tsx#L48">src/component/NGLComponent.tsx:48</a></li>
+						</ul>
+					</aside>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface">
+					<a name="pickingproxy" class="tsd-anchor"></a>
+					<h3>picking<wbr>Proxy</h3>
+					<div class="tsd-signature tsd-kind-icon">picking<wbr>Proxy<span class="tsd-signature-symbol">:</span> <a href="../classes/_ngl_.pickingproxy.html" class="tsd-signature-type">PickingProxy</a></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/cBioCenter/bioblocks-viz/blob/10ae9ca5a/src/component/NGLComponent.tsx#L49">src/component/NGLComponent.tsx:49</a></li>
+						</ul>
+					</aside>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface">
+					<a name="stage" class="tsd-anchor"></a>
+					<h3>stage</h3>
+					<div class="tsd-signature tsd-kind-icon">stage<span class="tsd-signature-symbol">:</span> <a href="../classes/_ngl_.stage.html" class="tsd-signature-type">Stage</a></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/cBioCenter/bioblocks-viz/blob/10ae9ca5a/src/component/NGLComponent.tsx#L50">src/component/NGLComponent.tsx:50</a></li>
+						</ul>
+					</aside>
+				</section>
+			</section>
+		</div>
+		<div class="col-4 col-menu menu-sticky-wrap menu-highlight">
+			<nav class="tsd-navigation primary">
+				<ul>
+					<li class="globals  ">
+						<a href="../globals.html"><em>Globals</em></a>
+					</li>
+				</ul>
+			</nav>
+			<nav class="tsd-navigation secondary menu-sticky">
+				<ul class="before-current">
+				</ul>
+				<ul class="current">
+					<li class="current tsd-kind-interface">
+						<a href="inglhoverinfo.html" class="tsd-kind-icon">INGLHover<wbr>Info</a>
+						<ul>
+							<li class=" tsd-kind-property tsd-parent-kind-interface">
+								<a href="inglhoverinfo.html#atom" class="tsd-kind-icon">atom</a>
+							</li>
+							<li class=" tsd-kind-property tsd-parent-kind-interface">
+								<a href="inglhoverinfo.html#pickingproxy" class="tsd-kind-icon">picking<wbr>Proxy</a>
+							</li>
+							<li class=" tsd-kind-property tsd-parent-kind-interface">
+								<a href="inglhoverinfo.html#stage" class="tsd-kind-icon">stage</a>
+							</li>
+						</ul>
+					</li>
+				</ul>
+				<ul class="after-current">
+				</ul>
+			</nav>
+		</div>
+	</div>
+</div>
+<footer class="with-border-bottom">
+	<div class="container">
+		<h2>Legend</h2>
+		<div class="tsd-legend-group">
+			<ul class="tsd-legend">
+				<li class="tsd-kind-module"><span class="tsd-kind-icon">Module</span></li>
+				<li class="tsd-kind-object-literal"><span class="tsd-kind-icon">Object literal</span></li>
+				<li class="tsd-kind-variable"><span class="tsd-kind-icon">Variable</span></li>
+				<li class="tsd-kind-function"><span class="tsd-kind-icon">Function</span></li>
+				<li class="tsd-kind-function tsd-has-type-parameter"><span class="tsd-kind-icon">Function with type parameter</span></li>
+				<li class="tsd-kind-index-signature"><span class="tsd-kind-icon">Index signature</span></li>
+				<li class="tsd-kind-type-alias"><span class="tsd-kind-icon">Type alias</span></li>
+				<li class="tsd-kind-type-alias tsd-has-type-parameter"><span class="tsd-kind-icon">Type alias with type parameter</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-enum"><span class="tsd-kind-icon">Enumeration</span></li>
+				<li class="tsd-kind-enum-member"><span class="tsd-kind-icon">Enumeration member</span></li>
+				<li class="tsd-kind-property tsd-parent-kind-enum"><span class="tsd-kind-icon">Property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-enum"><span class="tsd-kind-icon">Method</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-interface"><span class="tsd-kind-icon">Interface</span></li>
+				<li class="tsd-kind-interface tsd-has-type-parameter"><span class="tsd-kind-icon">Interface with type parameter</span></li>
+				<li class="tsd-kind-constructor tsd-parent-kind-interface"><span class="tsd-kind-icon">Constructor</span></li>
+				<li class="tsd-kind-property tsd-parent-kind-interface"><span class="tsd-kind-icon">Property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-interface"><span class="tsd-kind-icon">Method</span></li>
+				<li class="tsd-kind-index-signature tsd-parent-kind-interface"><span class="tsd-kind-icon">Index signature</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-class"><span class="tsd-kind-icon">Class</span></li>
+				<li class="tsd-kind-class tsd-has-type-parameter"><span class="tsd-kind-icon">Class with type parameter</span></li>
+				<li class="tsd-kind-constructor tsd-parent-kind-class"><span class="tsd-kind-icon">Constructor</span></li>
+				<li class="tsd-kind-property tsd-parent-kind-class"><span class="tsd-kind-icon">Property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-class"><span class="tsd-kind-icon">Method</span></li>
+				<li class="tsd-kind-accessor tsd-parent-kind-class"><span class="tsd-kind-icon">Accessor</span></li>
+				<li class="tsd-kind-index-signature tsd-parent-kind-class"><span class="tsd-kind-icon">Index signature</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited constructor</span></li>
+				<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited method</span></li>
+				<li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited accessor</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><span class="tsd-kind-icon">Protected property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected"><span class="tsd-kind-icon">Protected method</span></li>
+				<li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-protected"><span class="tsd-kind-icon">Protected accessor</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><span class="tsd-kind-icon">Private property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><span class="tsd-kind-icon">Private method</span></li>
+				<li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-private"><span class="tsd-kind-icon">Private accessor</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-property tsd-parent-kind-class tsd-is-static"><span class="tsd-kind-icon">Static property</span></li>
+				<li class="tsd-kind-call-signature tsd-parent-kind-class tsd-is-static"><span class="tsd-kind-icon">Static method</span></li>
+			</ul>
+		</div>
+	</div>
+</footer>
+<div class="container tsd-generator">
+	<p>Generated using <a href="https://typedoc.org/" target="_blank">TypeDoc</a></p>
+</div>
+<div class="overlay"></div>
+<script src="../assets/js/main.js"></script>
+<script>if (location.protocol == 'file:') document.write('<script src="../assets/js/search.js"><' + '/script>');</script>
+</body>
+</html>

--- a/docs/stories/visualization/NGL.stories.tsx
+++ b/docs/stories/visualization/NGL.stories.tsx
@@ -2,7 +2,6 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 
 import { NGLContainer } from '~bioblocks-viz~/container';
-import { BioblocksPDB } from '~bioblocks-viz~/data';
 
 const stories = storiesOf('visualization/NGL', module).addParameters({ component: NGLContainer });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioblocks-viz",
-  "version": "0.0.153",
+  "version": "0.0.154",
   "author": "Biostatistics and Computational Biology at Dana-Farber <bcb@jimmy.harvard.edu>",
   "contributors": [
     "Andrew Diamantoukos <MercifulCode@gmail.com",

--- a/src/component/NGLComponent.tsx
+++ b/src/component/NGLComponent.tsx
@@ -16,7 +16,7 @@ import * as React from 'react';
 import { Dimmer, Loader } from 'semantic-ui-react';
 import { Matrix4, Vector2 } from 'three';
 
-import { ComponentCard, IComponentMenuBarItem, IDockItem } from '~bioblocks-viz~/component';
+import { ComponentCard, IComponentCardProps, IComponentMenuBarItem, IDockItem } from '~bioblocks-viz~/component';
 import {
   BIOBLOCKS_CSS_STYLE,
   BioblocksPDB,
@@ -53,6 +53,7 @@ export interface INGLHoverInfo {
 export interface INGLComponentProps {
   backgroundColor: string | number;
   candidateResidues: RESIDUE_TYPE[];
+  cardProps: IComponentCardProps;
   experimentalProteins: BioblocksPDB[];
   height: number | string;
   hoveredResidues: RESIDUE_TYPE[];
@@ -105,6 +106,7 @@ export class NGLComponent extends React.Component<INGLComponentProps, NGLCompone
     addLockedResiduePair: EMPTY_FUNCTION,
     backgroundColor: '#ffffff',
     candidateResidues: [],
+    cardProps: {},
     experimentalProteins: [],
     height: '92%',
     hoveredResidueTooltipTextCb: (hoverInfo: INGLHoverInfo) => {
@@ -211,27 +213,39 @@ export class NGLComponent extends React.Component<INGLComponentProps, NGLCompone
    * @returns The NGL Component
    */
   public render() {
-    const { experimentalProteins, height, isDataLoading, menuItems, predictedProteins, style, width } = this.props;
+    const {
+      cardProps,
+      experimentalProteins,
+      height,
+      isDataLoading,
+      menuItems,
+      predictedProteins,
+      style,
+      width,
+    } = this.props;
     const computedStyle = { ...style, height, width };
 
     return (
       <ComponentCard
-        componentName={'NGL Viewer'}
-        dockItems={this.getDockItems()}
-        isDataReady={experimentalProteins.length >= 1 || predictedProteins.length >= 1}
-        menuItems={[
-          ...menuItems,
-          {
-            component: {
-              configs: { ...this.getSettingsConfigurations(), ...this.getRepresentationConfigs() },
-              name: 'POPUP',
-              props: {
-                position: 'top center',
+        {...{
+          componentName: 'NGL Viewer',
+          dockItems: this.getDockItems(),
+          isDataReady: experimentalProteins.length >= 1 || predictedProteins.length >= 1,
+          menuItems: [
+            ...menuItems,
+            {
+              component: {
+                configs: { ...this.getSettingsConfigurations(), ...this.getRepresentationConfigs() },
+                name: 'POPUP',
+                props: {
+                  position: 'top center',
+                },
               },
+              description: 'Settings',
             },
-            description: 'Settings',
-          },
-        ]}
+          ],
+          ...cardProps,
+        }}
       >
         <div className={'NGLComponent'} style={computedStyle}>
           <Dimmer active={isDataLoading}>

--- a/src/component/__tests__/NGLComponent.test.tsx
+++ b/src/component/__tests__/NGLComponent.test.tsx
@@ -6,6 +6,7 @@ import { Checkbox, Popup } from 'semantic-ui-react';
 import { NGLComponent } from '~bioblocks-viz~/component';
 import { BioblocksPDB, CONTACT_DISTANCE_PROXIMITY } from '~bioblocks-viz~/data';
 import { NGLInstanceManager } from '~bioblocks-viz~/helper';
+import { flushPromises } from '~bioblocks-viz~/test';
 
 describe('NGLComponent', () => {
   let sampleData: BioblocksPDB[];
@@ -321,6 +322,35 @@ describe('NGLComponent', () => {
 
       wrapper.find('.NGLCanvas').simulate('mouseleave');
       expect(removeNonLockedResiduesSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should clear candidate and hovered residues when the clear selection button is clicked.', async () => {
+      const wrapper = mount(<NGLComponent predictedProteins={sampleData} />);
+      const removeAllLockedResiduePairsSpy = jest.fn();
+      const removeAllSelectedSecondaryStructuresSpy = jest.fn();
+      const removeCandidateResiduesSpy = jest.fn();
+      const removeHoveredResiduesSpy = jest.fn();
+
+      wrapper.setProps({
+        candidateResidues: [3],
+        hoveredResidues: [4],
+        removeAllLockedResiduePairs: removeAllLockedResiduePairsSpy,
+        removeAllSelectedSecondaryStructures: removeAllSelectedSecondaryStructuresSpy,
+        removeCandidateResidues: removeCandidateResiduesSpy,
+        removeHoveredResidues: removeHoveredResiduesSpy,
+      });
+
+      await flushPromises();
+
+      wrapper
+        .find('a')
+        .at(1)
+        .simulate('click');
+
+      expect(removeAllLockedResiduePairsSpy).toHaveBeenCalledTimes(1);
+      expect(removeAllSelectedSecondaryStructuresSpy).toHaveBeenCalledTimes(1);
+      expect(removeCandidateResiduesSpy).toHaveBeenCalledTimes(1);
+      expect(removeHoveredResiduesSpy).toHaveBeenCalledTimes(1);
     });
 
     // tslint:disable-next-line:mocha-no-side-effect-code

--- a/src/container/__tests__/NGLContainer.test.tsx
+++ b/src/container/__tests__/NGLContainer.test.tsx
@@ -200,7 +200,7 @@ describe('NGLContainer', () => {
     expect(instance.state.selectedPredictedProteins).toEqual([]);
   });
 
-  it.skip('Should show the correct sequence match.', async () => {
+  it('Should show the correct sequence match.', async () => {
     let experimentalPDB = await BioblocksPDB.createPDB('exp_1_sample');
     let predictedPDB = await BioblocksPDB.createPDB('pred_1_sample');
 
@@ -219,12 +219,15 @@ describe('NGLContainer', () => {
     wrapper.update();
 
     await flushPromises();
-    const foo = wrapper.text();
+    wrapper
+      .find(Popup)
+      .at(0)
+      .simulate('click');
 
     expect(
       wrapper
         .find(Table.Cell)
-        .at(1)
+        .at(4)
         .text(),
     ).toEqual('100.0%');
 
@@ -238,6 +241,12 @@ describe('NGLContainer', () => {
       experimentalProteins: [experimentalPDB],
       predictedProteins: [predictedPDB],
     });
+
+    await flushPromises();
+    wrapper
+      .find(Popup)
+      .at(0)
+      .simulate('click');
 
     expect(
       wrapper

--- a/src/container/__tests__/__snapshots__/NGLContainer.test.tsx.snap
+++ b/src/container/__tests__/__snapshots__/NGLContainer.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`NGLContainer Should match the default snapshot when hooked up to a redu
                   addLockedResiduePair={[Function]}
                   backgroundColor="#ffffff"
                   candidateResidues={Array []}
+                  cardProps={Object {}}
                   dispatchNglFetch={[Function]}
                   experimentalProteins={Array []}
                   height="92%"
@@ -1305,6 +1306,7 @@ exports[`NGLContainer Should match the default snapshot when not hooked up to a 
       addLockedResiduePair={[Function]}
       backgroundColor="#ffffff"
       candidateResidues={Array []}
+      cardProps={Object {}}
       dispatchNglFetch={[Function]}
       experimentalProteins={Array []}
       height="92%"


### PR DESCRIPTION
Added `cardProps` prop to NGLComponent - can be passed to NGLComponent or NGLContainer to override props for the inner ComponentCard.

Future work will involve having a more standardized HOC for passing card props to the components that use it.

--- 

Nowadays everybody wanna talk like they got some requests
But nothing comes out when they move their lips
Just a bunch of gibberish
And ************* act like they forgot about tests